### PR TITLE
In security config permit only /api prefixed endpoints(but rejected b…

### DIFF
--- a/src/main/java/net/burndmg/eschallenges/controller/ChallengeAcceptanceController.java
+++ b/src/main/java/net/burndmg/eschallenges/controller/ChallengeAcceptanceController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 @RestController
-@RequestMapping("challenges/{id}/acceptances")
+@RequestMapping("api/challenges/{id}/acceptances")
 @RequiredArgsConstructor
 public class ChallengeAcceptanceController {
 

--- a/src/main/java/net/burndmg/eschallenges/controller/ChallengeManagementController.java
+++ b/src/main/java/net/burndmg/eschallenges/controller/ChallengeManagementController.java
@@ -15,7 +15,7 @@ import static net.burndmg.eschallenges.infrastructure.config.security.SecurityAu
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("challenges")
+@RequestMapping("api/challenges")
 @PreAuthorize("hasAuthority('" + CHALLENGE_MANAGEMENT_PRIVILEGE + "')")
 public class ChallengeManagementController {
 

--- a/src/main/java/net/burndmg/eschallenges/controller/ParticipantChallengesController.java
+++ b/src/main/java/net/burndmg/eschallenges/controller/ParticipantChallengesController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 @RestController
-@RequestMapping("challenges")
+@RequestMapping("api/challenges")
 @RequiredArgsConstructor
 public class ParticipantChallengesController {
 

--- a/src/main/java/net/burndmg/eschallenges/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/net/burndmg/eschallenges/infrastructure/config/security/SecurityConfig.java
@@ -29,8 +29,9 @@ public class SecurityConfig {
     @Bean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     SecurityWebFilterChain filterChain(ServerHttpSecurity http) {
-        // permit here but we will reject everything in customAuthorize
-        return http.authorizeExchange(registry -> registry.anyExchange().permitAll())
+        // permit /api here, but we will reject everything in customAuthorize
+        return http.authorizeExchange(registry -> registry.pathMatchers("/api/**").permitAll()
+                                                          .anyExchange().denyAll())
                    .csrf(ServerHttpSecurity.CsrfSpec::disable)
                    .build();
     }

--- a/src/test/java/net/burndmg/eschallenges/integration/NotSecuredEndpointIntegrationTest.java
+++ b/src/test/java/net/burndmg/eschallenges/integration/NotSecuredEndpointIntegrationTest.java
@@ -3,6 +3,7 @@ package net.burndmg.eschallenges.integration;
 import net.burndmg.eschallenges.integration.util.IntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 
 public class NotSecuredEndpointIntegrationTest extends IntegrationTestBase {
@@ -11,5 +12,16 @@ public class NotSecuredEndpointIntegrationTest extends IntegrationTestBase {
     @WithMockUser(roles = "ADMIN")
     void whenTryingToCallNotSecuredEndpoint_shouldBeRejected() {
         get("/not-secured-integration-test-endpoint").expectStatus().isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void whenTryingToCallNotSecuredEndpointWithoutApiPrefix_shouldBeRejected() {
+        webTestClient
+                .get()
+                .uri("not-secured-and-not-api-integration-test-endpoint")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.FORBIDDEN);
     }
 }

--- a/src/test/java/net/burndmg/eschallenges/integration/ParticipantChallengesControllerIntegrationTest.java
+++ b/src/test/java/net/burndmg/eschallenges/integration/ParticipantChallengesControllerIntegrationTest.java
@@ -4,7 +4,6 @@ import net.burndmg.eschallenges.data.dto.participant.ParticipantChallengePage;
 import net.burndmg.eschallenges.data.model.Challenge;
 import net.burndmg.eschallenges.integration.util.IntegrationTestBase;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -82,15 +81,7 @@ public class ParticipantChallengesControllerIntegrationTest extends IntegrationT
         testIndexer.indexRandomChallengeAndReturnIt("1");
         testIndexer.indexRandomChallengeAndReturnIt("2");
 
-        ParticipantChallengePage firstResponseBody = webTestClient
-                .get()
-                .uri("/challenges")
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().is2xxSuccessful()
-                .expectBody(ParticipantChallengePage.class)
-                .returnResult()
-                .getResponseBody();
+        ParticipantChallengePage firstResponseBody = getSuccessful("/challenges", ParticipantChallengePage.class);
 
         assertNotNull(firstResponseBody);
 

--- a/src/test/java/net/burndmg/eschallenges/integration/util/IntegrationTestBase.java
+++ b/src/test/java/net/burndmg/eschallenges/integration/util/IntegrationTestBase.java
@@ -41,7 +41,7 @@ public abstract class IntegrationTestBase implements ElasticsearchAware {
     protected WebTestClient.ResponseSpec get(String path) {
         return webTestClient
                 .get()
-                .uri(path)
+                .uri("/api" + path)
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange();
     }
@@ -63,7 +63,7 @@ public abstract class IntegrationTestBase implements ElasticsearchAware {
     protected WebTestClient.ResponseSpec post(String path, Object body) {
         return webTestClient
                 .post()
-                .uri(path)
+                .uri("/api" + path)
                 .accept(MediaType.APPLICATION_JSON)
                 .bodyValue(body)
                 .exchange();
@@ -86,7 +86,7 @@ public abstract class IntegrationTestBase implements ElasticsearchAware {
     protected WebTestClient.ResponseSpec put(String path, Object body) {
         return webTestClient
                 .put()
-                .uri(path)
+                .uri("/api" + path)
                 .accept(MediaType.APPLICATION_JSON)
                 .bodyValue(body)
                 .exchange();

--- a/src/test/java/net/burndmg/eschallenges/integration/util/NotSecuredController.java
+++ b/src/test/java/net/burndmg/eschallenges/integration/util/NotSecuredController.java
@@ -8,8 +8,13 @@ import reactor.core.publisher.Mono;
 public class NotSecuredController {
 
 
-    @GetMapping("not-secured-integration-test-endpoint")
+    @GetMapping("api/not-secured-integration-test-endpoint")
     public Mono<String> test() {
+        return Mono.just("You will never see this string");
+    }
+
+    @GetMapping("not-secured-and-not-api-integration-test-endpoint")
+    public Mono<String> test2() {
         return Mono.just("You will never see this string");
     }
 }


### PR DESCRIPTION
…y default by custom authorizer) just in case something like /actuator will be presented by some library - so we need to enable them manually